### PR TITLE
New Resources: Disk and Disk_Attachment

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ are also used, if applicable:
 
 ## Argument Reference
 
-In addition to [generic `provider` arguments](https://www.terraform.io/docs/configuration/providers.html)
+In addition to generic `provider` arguments:
 (e.g., `alias` and `version`), the following arguments are supported in the AWS
  `provider` block:
 

--- a/docs/resources/disk.md
+++ b/docs/resources/disk.md
@@ -15,8 +15,8 @@ Creates a Lightsail Disk resource.
 ```terraform
 resource "awslightsail_disk" "test" {
   name              = "test"
-  size_in_gb = 8
-  availability_zone     = "us-east-1"
+  size_in_gb        = 8
+  availability_zone = "us-east-1"
 }
 ```
 

--- a/docs/resources/disk.md
+++ b/docs/resources/disk.md
@@ -1,0 +1,44 @@
+---
+page_title: "AWS Lightsail: awslightsail_disk"
+description: |-
+  Provides a Lightsail Disk
+---
+
+# Resource: awslightsail_disk
+
+Creates a Lightsail Disk resource.
+
+~> **Note:** Lightsail is currently only supported in a limited number of AWS Regions, please see ["Regions and Availability Zones in Amazon Lightsail"](https://lightsail.aws.amazon.com/ls/docs/overview/article/understanding-regions-and-availability-zones-in-amazon-lightsail) for more details
+
+## Example Usage
+
+```terraform
+resource "awslightsail_disk" "test" {
+  name              = "test"
+  size_in_gb = 8
+  availability_zone     = "us-east-1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Lightsail load balancer.
+* `size_in_gb` - (Required) The instance port the load balancer will connect.
+* `availability_zone` - (Required) The Availability Zone in which to create your disk.
+* `tags` - (Optional) A map of tags to assign to the resource. To create a key-only tag, use an empty string as the value. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the Lightsail load balancer.
+* `created_at` - The timestamp when the load balancer was created.
+* `id` - The name of the disk  (matches `name`).
+
+Lightsail Disks can be imported using their name, e.g.
+
+```shell
+$ terraform import awslightsail_disk.test 'test'
+```

--- a/docs/resources/disk_attachment.md
+++ b/docs/resources/disk_attachment.md
@@ -16,10 +16,10 @@ Attaches a Lightsail disk to a Lightsail Instance
 data "awslightsail_availability_zones" "all" {}
 
 resource "awslightsail_disk" "test" {
-	name              = "test"
-	size_in_gb = 8
-	availability_zone     = data.awslightsail_availability_zones.all.names[0]
-  }
+  name              = "test"
+  size_in_gb        = 8
+  availability_zone = data.awslightsail_availability_zones.all.names[0]
+}
 
 resource "awslightsail_instance" "test" {
   name              = "test"
@@ -29,9 +29,9 @@ resource "awslightsail_instance" "test" {
 }
 
 resource "awslightsail_disk_attachment" "test" {
-  disk_name = awslightsail_disk.test.name
-  instance_name      = awslightsail_instance.test.name
-  disk_path = "/dev/xvdf"
+  disk_name     = awslightsail_disk.test.name
+  instance_name = awslightsail_instance.test.name
+  disk_path     = "/dev/xvdf"
 }
 ```
 

--- a/docs/resources/disk_attachment.md
+++ b/docs/resources/disk_attachment.md
@@ -1,0 +1,59 @@
+---
+page_title: "AWS Lightsail: awslightsail_disk_attachment"
+description: |-
+  Provides a Lightsail Disk attachment
+---
+
+# Resource: awslightsail_disk_attachment
+
+Attaches a Lightsail disk to a Lightsail Instance
+
+~> **Note:** Lightsail is currently only supported in a limited number of AWS Regions, please see ["Regions and Availability Zones in Amazon Lightsail"](https://lightsail.aws.amazon.com/ls/docs/overview/article/understanding-regions-and-availability-zones-in-amazon-lightsail) for more details
+
+## Example Usage
+
+```terraform
+data "awslightsail_availability_zones" "all" {}
+
+resource "awslightsail_disk" "test" {
+	name              = "test"
+	size_in_gb = 8
+	availability_zone     = data.awslightsail_availability_zones.all.names[0]
+  }
+
+resource "awslightsail_instance" "test" {
+  name              = "test"
+  availability_zone = data.awslightsail_availability_zones.all.names[0]
+  blueprint_id      = "amazon_linux"
+  bundle_id         = "nano_1_0"
+}
+
+resource "awslightsail_disk_attachment" "test" {
+  disk_name = awslightsail_disk.test.name
+  instance_name      = awslightsail_instance.test.name
+  disk_path = "/dev/xvdf"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Lightsail load balancer.
+* `size_in_gb` - (Required) The instance port the load balancer will connect.
+* `availability_zone` - (Required) The Availability Zone in which to create your disk.
+* `tags` - (Optional) A map of tags to assign to the resource. To create a key-only tag, use an empty string as the value. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the Lightsail load balancer.
+* `created_at` - The timestamp when the load balancer was created.
+* `id` - The name of the disk  (matches `name`).
+
+Lightsail Disks can be imported using their name, e.g.
+
+```shell
+$ terraform import awslightsail_disk_attachment.test 'test'
+```

--- a/internal/lightsail/disk.go
+++ b/internal/lightsail/disk.go
@@ -1,0 +1,184 @@
+package lightsail
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lightsail"
+	"github.com/aws/smithy-go"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/conns"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/tftags"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/verify"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func ResourceDisk() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDiskCreate,
+		Read:   resourceDiskRead,
+		Update: resourceDiskUpdate,
+		Delete: resourceDiskDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(2, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with an alphabetic character"),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+[^._\-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+				),
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"size_in_gb": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"tags":     TagsSchema(),
+			"tags_all": TagsSchemaComputed(),
+			// additional info returned from the API
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceDiskCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LightsailConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	req := lightsail.CreateDiskInput{
+		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
+		SizeInGb:         aws.Int32(int32((d.Get("size_in_gb").(int)))),
+		DiskName:         aws.String(d.Get("name").(string)),
+	}
+
+	if len(tags) > 0 {
+		req.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	resp, err := conn.CreateDisk(context.TODO(), &req)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Operations) == 0 {
+		return fmt.Errorf("No operations found for CreateDisk request")
+	}
+
+	op := resp.Operations[0]
+	d.SetId(d.Get("name").(string))
+
+	err = waitLightsailOperation(conn, op.Id)
+	if err != nil {
+		return fmt.Errorf("Error waiting for Relational Database (%s) to become ready: %s", d.Id(), err)
+	}
+
+	return resourceDiskRead(d, meta)
+}
+
+func resourceDiskRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LightsailConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	resp, err := conn.GetDisk(context.TODO(), &lightsail.GetDiskInput{
+		DiskName: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		var oe *smithy.OperationError
+		if errors.As(err, &oe) {
+			log.Printf("failed to call service: %s, operation: %s, error: %v", oe.Service(), oe.Operation(), oe.Unwrap())
+		}
+		d.SetId("")
+		return nil
+	}
+
+	if resp == nil {
+		log.Printf("[WARN] Lightsail Disk (%s) not found, nil response from server, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	i := resp.Disk
+
+	d.Set("availability_zone", i.Location.AvailabilityZone)
+	d.Set("size_in_gb", i.SizeInGb)
+	d.Set("name", i.Name)
+
+	// additional attributes
+	d.Set("arn", i.Arn)
+	d.Set("created_at", i.CreatedAt.Format(time.RFC3339))
+
+	tags := KeyValueTags(i.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceDiskDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	resp, err := conn.DeleteDisk(context.TODO(), &lightsail.DeleteDiskInput{
+		DiskName: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	op := resp.Operations[0]
+
+	err = waitLightsailOperation(conn, op.Id)
+	if err != nil {
+		return fmt.Errorf("Error waiting for Disk (%s) to become ready: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceDiskUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating Lightsail Disk (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceDiskRead(d, meta)
+}

--- a/internal/lightsail/disk_attachment.go
+++ b/internal/lightsail/disk_attachment.go
@@ -1,0 +1,177 @@
+package lightsail
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lightsail"
+	"github.com/aws/smithy-go"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/conns"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ResourceDiskAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDiskAttachmentCreate,
+		Read:   resourceDiskAttachmentRead,
+		Delete: resourceDiskAttachmentDelete,
+
+		Schema: map[string]*schema.Schema{
+			"disk_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"disk_path": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceDiskAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	resp, err := conn.AttachDisk(context.TODO(), &lightsail.AttachDiskInput{
+		DiskName:     aws.String(d.Get("disk_name").(string)),
+		InstanceName: aws.String(d.Get("instance_name").(string)),
+		DiskPath:     aws.String(d.Get("disk_path").(string)),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	op := resp.Operations[0]
+
+	err = waitLightsailOperation(conn, op.Id)
+	if err != nil {
+		return fmt.Errorf("Error waiting for disk Attachent (%s) to become ready: %s", d.Id(), err)
+	}
+
+	// Generate an ID
+	vars := []string{
+		d.Get("disk_name").(string),
+		d.Get("instance_name").(string),
+	}
+
+	d.SetId(strings.Join(vars, "_"))
+
+	return resourceDiskAttachmentRead(d, meta)
+}
+
+func resourceDiskAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	id_parts := strings.SplitN(d.Id(), "_", -1)
+	if len(id_parts) != 2 {
+		return nil
+	}
+
+	dname := id_parts[0]
+	iname := id_parts[1]
+
+	resp, err := conn.GetDisk(context.TODO(), &lightsail.GetDiskInput{
+		DiskName: aws.String(dname),
+	})
+
+	if err != nil {
+		var oe *smithy.OperationError
+		if errors.As(err, &oe) {
+			log.Printf("failed to call service: %s, operation: %s, error: %v", oe.Service(), oe.Operation(), oe.Unwrap())
+		}
+		d.SetId("")
+		return nil
+	}
+
+	disk := resp.Disk
+
+	if !*disk.IsAttached {
+		log.Printf("[WARN] Lightsail Disk (%s) is not attached, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if *disk.AttachedTo != iname {
+		log.Printf("[WARN] Lightsail Disk (%s) is not attached, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("instance_name", disk.AttachedTo)
+	d.Set("disk_name", disk.Name)
+	d.Set("disk_path", disk.Path)
+
+	return nil
+}
+
+func resourceDiskAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	id_parts := strings.SplitN(d.Id(), "_", -1)
+	if len(id_parts) != 2 {
+		return nil
+	}
+
+	dname := id_parts[0]
+	iname := id_parts[1]
+
+	// You must first Stop an instance in order to detach a disk.
+	stopresp, stoperr := conn.StopInstance(context.TODO(), &lightsail.StopInstanceInput{
+		InstanceName: aws.String(iname),
+	})
+
+	if stoperr != nil {
+		return stoperr
+	}
+
+	stopop := stopresp.Operations[0]
+
+	stoperr = waitLightsailOperation(conn, stopop.Id)
+	if stoperr != nil {
+		return fmt.Errorf("Error waiting for Instance (%s) to Stop: %s", iname, stoperr)
+	}
+
+	resp, err := conn.DetachDisk(context.TODO(), &lightsail.DetachDiskInput{
+		DiskName: aws.String(dname),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	op := resp.Operations[0]
+
+	err = waitLightsailOperation(conn, op.Id)
+	if err != nil {
+		return fmt.Errorf("Error waiting for disk Attachent (%s) to become ready: %s", d.Id(), err)
+	}
+
+	startresp, starterr := conn.StartInstance(context.TODO(), &lightsail.StartInstanceInput{
+		InstanceName: aws.String(iname),
+	})
+
+	if starterr != nil {
+		return err
+	}
+
+	startop := startresp.Operations[0]
+
+	starterr = waitLightsailOperation(conn, startop.Id)
+	if starterr != nil {
+		return fmt.Errorf("Error waiting for Instance to Start (%s) to become ready: %s", iname, starterr)
+	}
+
+	return nil
+}

--- a/internal/lightsail/disk_attachment_test.go
+++ b/internal/lightsail/disk_attachment_test.go
@@ -1,0 +1,202 @@
+package lightsail_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lightsail"
+	"github.com/aws/smithy-go"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/conns"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/testhelper"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDiskAttachment_basic(t *testing.T) {
+	rName := "awslightsail_disk_attachment.test"
+	ldName := acctest.RandomWithPrefix("tf-acc-test")
+	liName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testhelper.GetProviders(),
+		CheckDestroy: testAccCheckDiskAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiskAttachmentConfigBasic(ldName, liName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskAttachmentExists(rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDiskAttachment_disappears(t *testing.T) {
+	rName := "awslightsail_disk_attachment.test"
+	ldName := acctest.RandomWithPrefix("tf-acc-test")
+	liName := acctest.RandomWithPrefix("tf-acc-test")
+
+	testDestroy := func(*terraform.State) error {
+		// reach out and detach Instance from the Load Balancer
+		conn := testhelper.GetProvider().Meta().(*conns.AWSClient).LightsailConn
+
+		// You must first Stop an instance in order to detach a disk.
+		stopresp, stoperr := conn.StopInstance(context.TODO(), &lightsail.StopInstanceInput{
+			InstanceName: aws.String(liName),
+		})
+
+		if stoperr != nil {
+			return stoperr
+		}
+
+		stopop := stopresp.Operations[0]
+
+		stoperr = testhelper.WaitLightsailOperation(conn, stopop.Id)
+		if stoperr != nil {
+			return fmt.Errorf("Error waiting for Instance (%s) to Stop: %s", liName, stoperr)
+		}
+
+		resp, err := conn.DetachDisk(context.TODO(), &lightsail.DetachDiskInput{
+			DiskName: aws.String(ldName),
+		})
+
+		if err != nil {
+			return fmt.Errorf("error detaching disk")
+		}
+
+		op := resp.Operations[0]
+
+		err = testhelper.WaitLightsailOperation(conn, op.Id)
+		if err != nil {
+			return fmt.Errorf("Error waiting for disk attatchment (%s) to become ready: %s", ldName, err)
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers: testhelper.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiskAttachmentConfigBasic(ldName, liName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskAttachmentExists(rName),
+					testDestroy,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDiskAttachmentExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No LightsailDiskAttachment ID is set")
+		}
+
+		conn := testhelper.GetProvider().Meta().(*conns.AWSClient).LightsailConn
+
+		id_parts := strings.SplitN(rs.Primary.ID, "_", -1)
+
+		if len(id_parts) != 2 {
+			return nil
+		}
+
+		ldName := id_parts[0]
+		liName := id_parts[1]
+
+		resp, err := conn.GetDisk(context.TODO(), &lightsail.GetDiskInput{
+			DiskName: aws.String(ldName),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || resp.Disk == nil {
+			return fmt.Errorf("Disk (%s) not found", ldName)
+		}
+
+		if *resp.Disk.AttachedTo != liName {
+			return fmt.Errorf("Disk Attachment (%s) not found", ldName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDiskAttachmentDestroy(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "awslightsail_disk_attachment" {
+			continue
+		}
+
+		conn := testhelper.GetProvider().Meta().(*conns.AWSClient).LightsailConn
+
+		id_parts := strings.SplitN(rs.Primary.ID, "_", -1)
+		if len(id_parts) != 2 {
+			return nil
+		}
+
+		ldName := id_parts[0]
+
+		resp, err := conn.GetDisk(context.TODO(), &lightsail.GetDiskInput{
+			DiskName: aws.String(ldName),
+		})
+
+		// Verify the error
+		if err != nil {
+			var oe *smithy.OperationError
+			if errors.As(err, &oe) {
+				log.Printf("failed to call service: %s, operation: %s, error: %v", oe.Service(), oe.Operation(), oe.Unwrap())
+			}
+			return nil
+		}
+
+		if *resp.Disk.AttachedTo == ldName {
+			return fmt.Errorf("Disk Attachment (%s) still exists.", ldName)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccDiskAttachmentConfigBasic(ldName string, liName string) string {
+	return fmt.Sprintf(`
+data "awslightsail_availability_zones" "all" {}
+
+resource "awslightsail_disk" "test" {
+	name              = %[1]q
+	size_in_gb = "8"
+	availability_zone     = data.awslightsail_availability_zones.all.names[0]
+  }
+
+resource "awslightsail_instance" "test" {
+  name              = %[2]q
+  availability_zone = data.awslightsail_availability_zones.all.names[0]
+  blueprint_id      = "amazon_linux"
+  bundle_id         = "nano_1_0"
+}
+
+resource "awslightsail_disk_attachment" "test" {
+  disk_name = awslightsail_disk.test.name
+  instance_name      = awslightsail_instance.test.name
+  disk_path = "/dev/xvdf"
+}
+`, ldName, liName)
+}

--- a/internal/lightsail/disk_attachment_test.go
+++ b/internal/lightsail/disk_attachment_test.go
@@ -181,10 +181,10 @@ func testAccDiskAttachmentConfigBasic(ldName string, liName string) string {
 data "awslightsail_availability_zones" "all" {}
 
 resource "awslightsail_disk" "test" {
-	name              = %[1]q
-	size_in_gb = "8"
-	availability_zone     = data.awslightsail_availability_zones.all.names[0]
-  }
+  name              = %[1]q
+  size_in_gb        = "8"
+  availability_zone = data.awslightsail_availability_zones.all.names[0]
+}
 
 resource "awslightsail_instance" "test" {
   name              = %[2]q
@@ -194,9 +194,9 @@ resource "awslightsail_instance" "test" {
 }
 
 resource "awslightsail_disk_attachment" "test" {
-  disk_name = awslightsail_disk.test.name
-  instance_name      = awslightsail_instance.test.name
-  disk_path = "/dev/xvdf"
+  disk_name     = awslightsail_disk.test.name
+  instance_name = awslightsail_instance.test.name
+  disk_path     = "/dev/xvdf"
 }
 `, ldName, liName)
 }

--- a/internal/lightsail/disk_test.go
+++ b/internal/lightsail/disk_test.go
@@ -229,8 +229,8 @@ data "awslightsail_availability_zones" "all" {}
 
 resource "awslightsail_disk" "test" {
   name              = %[1]q
-  size_in_gb = 8
-  availability_zone     = data.awslightsail_availability_zones.all.names[0]
+  size_in_gb        = 8
+  availability_zone = data.awslightsail_availability_zones.all.names[0]
 }
 `, rName)
 }
@@ -240,9 +240,9 @@ func testAccDiskConfigTags1(rName string, tagKey1, tagValue1 string) string {
 data "awslightsail_availability_zones" "all" {}
 
 resource "awslightsail_disk" "test" {
-	name              = %[1]q
-	size_in_gb = 8
-	availability_zone     = data.awslightsail_availability_zones.all.names[0]
+  name              = %[1]q
+  size_in_gb        = 8
+  availability_zone = data.awslightsail_availability_zones.all.names[0]
   tags = {
     %[2]q = %[3]q
   }
@@ -255,9 +255,9 @@ func testAccDiskConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string
 data "awslightsail_availability_zones" "all" {}
 
 resource "awslightsail_disk" "test" {
-	name              = %[1]q
-	size_in_gb = 8
-	availability_zone     = data.awslightsail_availability_zones.all.names[0]
+  name              = %[1]q
+  size_in_gb        = 8
+  availability_zone = data.awslightsail_availability_zones.all.names[0]
   tags = {
     %[2]q = %[3]q
     %[4]q = %[5]q

--- a/internal/lightsail/disk_test.go
+++ b/internal/lightsail/disk_test.go
@@ -1,0 +1,267 @@
+package lightsail_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lightsail"
+	"github.com/aws/smithy-go"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/conns"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/testhelper"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDisk_basic(t *testing.T) {
+	rName := "awslightsail_disk.test"
+	lName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testhelper.GetProviders(),
+		CheckDestroy: testAccCheckDiskDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiskConfigBasic(lName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskExists(rName),
+					resource.TestCheckResourceAttr(rName, "size_in_gb", "8"),
+					resource.TestCheckResourceAttr(rName, "name", lName),
+					resource.TestCheckResourceAttrSet(rName, "arn"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDisk_Name(t *testing.T) {
+	rName := "awslightsail_disk.test"
+	lName := acctest.RandomWithPrefix("tf-acc-test")
+	lightsailNameWithSpaces := fmt.Sprint(rName, "string with spaces")
+	lightsailNameWithStartingDigit := fmt.Sprintf("01-%s", rName)
+	lightsailNameWithUnderscore := fmt.Sprintf("%s_123456", rName)
+
+	resource.Test(t, resource.TestCase{
+		Providers: testhelper.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDiskConfigBasic(lightsailNameWithSpaces),
+				ExpectError: regexp.MustCompile(`must contain only alphanumeric characters, underscores, hyphens, and dots`),
+			},
+			{
+				Config:      testAccDiskConfigBasic(lightsailNameWithStartingDigit),
+				ExpectError: regexp.MustCompile(`must begin with an alphabetic character`),
+			},
+			{
+				Config: testAccDiskConfigBasic(lName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDiskExists(rName),
+					resource.TestCheckResourceAttrSet(rName, "size_in_gb"),
+					resource.TestCheckResourceAttrSet(rName, "name"),
+				),
+			},
+			{
+				Config: testAccDiskConfigBasic(lightsailNameWithUnderscore),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDiskExists(rName),
+					resource.TestCheckResourceAttrSet(rName, "size_in_gb"),
+					resource.TestCheckResourceAttrSet(rName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDisk_Tags(t *testing.T) {
+	rName := "awslightsail_disk.test"
+	lName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		Providers: testhelper.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiskConfigTags1(lName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskExists(rName),
+					resource.TestCheckResourceAttr(rName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(rName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDiskConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskExists(rName),
+					resource.TestCheckResourceAttr(rName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(rName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(rName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccDiskConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskExists(rName),
+					resource.TestCheckResourceAttr(rName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(rName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDisk_disappears(t *testing.T) {
+	rName := "awslightsail_disk.test"
+	lName := acctest.RandomWithPrefix("tf-acc-test")
+
+	testDestroy := func(*terraform.State) error {
+		// reach out and DELETE the Disk
+		conn := testhelper.GetProvider().Meta().(*conns.AWSClient).LightsailConn
+		_, err := conn.DeleteDisk(context.TODO(), &lightsail.DeleteDiskInput{
+			DiskName: aws.String(lName),
+		})
+
+		if err != nil {
+			return fmt.Errorf("error deleting Lightsail Instance in disappear test")
+		}
+
+		// sleep 7 seconds to give it time, so we don't have to poll
+		time.Sleep(7 * time.Second)
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers: testhelper.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiskConfigBasic(lName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskExists(rName),
+					testDestroy,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDiskExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No LightsailDisk ID is set")
+		}
+
+		conn := testhelper.GetProvider().Meta().(*conns.AWSClient).LightsailConn
+
+		respDisk, err := conn.GetDisk(context.TODO(), &lightsail.GetDiskInput{
+			DiskName: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if respDisk == nil || respDisk.Disk == nil {
+			return fmt.Errorf("Disk (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDiskDestroy(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "awslightsail_disk" {
+			continue
+		}
+
+		conn := testhelper.GetProvider().Meta().(*conns.AWSClient).LightsailConn
+
+		resp, err := conn.GetDisk(context.TODO(), &lightsail.GetDiskInput{
+			DiskName: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			if resp.Disk != nil {
+				return fmt.Errorf("Lightsail Disk %q still exists", rs.Primary.ID)
+			}
+		}
+
+		// Verify the error
+		if err != nil {
+			var oe *smithy.OperationError
+			if errors.As(err, &oe) {
+				log.Printf("failed to call service: %s, operation: %s, error: %v", oe.Service(), oe.Operation(), oe.Unwrap())
+			}
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func testAccDiskConfigBasic(rName string) string {
+	return fmt.Sprintf(`
+data "awslightsail_availability_zones" "all" {}
+
+resource "awslightsail_disk" "test" {
+  name              = %[1]q
+  size_in_gb = 8
+  availability_zone     = data.awslightsail_availability_zones.all.names[0]
+}
+`, rName)
+}
+
+func testAccDiskConfigTags1(rName string, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+data "awslightsail_availability_zones" "all" {}
+
+resource "awslightsail_disk" "test" {
+	name              = %[1]q
+	size_in_gb = 8
+	availability_zone     = data.awslightsail_availability_zones.all.names[0]
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccDiskConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+data "awslightsail_availability_zones" "all" {}
+
+resource "awslightsail_disk" "test" {
+	name              = %[1]q
+	size_in_gb = 8
+	availability_zone     = data.awslightsail_availability_zones.all.names[0]
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/internal/lightsail/provider.go
+++ b/internal/lightsail/provider.go
@@ -73,6 +73,8 @@ func Provider() *schema.Provider {
 			"awslightsail_bucket":               ResourceBucket(),
 			"awslightsail_contact_method":       ResourceContactMethod(),
 			"awslightsail_database":             ResourceDatabase(),
+			"awslightsail_disk":                 ResourceDisk(),
+			"awslightsail_disk_attachment":      ResourceDiskAttachment(),
 			"awslightsail_domain":               ResourceDomain(),
 			"awslightsail_domain_entry":         ResourceDomainEntry(),
 			"awslightsail_instance":             ResourceInstance(),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10 
Closes #11 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
➜ terraform-provider-awslightsail (r-disk) ✗ make testacc TESTARGS='-run=TestAccDiskAttachment_' PKG_NAME='internal/lightsail'   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/lightsail/... -v -count 1 -parallel 20 -run=TestAccDiskAttachment_ -timeout 180m
=== RUN   TestAccDiskAttachment_basic
--- PASS: TestAccDiskAttachment_basic (207.58s)
=== RUN   TestAccDiskAttachment_disappears
--- PASS: TestAccDiskAttachment_disappears (143.06s)
PASS
ok      github.com/deyoungtech/terraform-provider-awslightsail/internal/lightsail       351.031s
➜ terraform-provider-awslightsail (r-disk) ✗ make testacc TESTARGS='-run=TestAccDisk_' PKG_NAME='internal/lightsail' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/lightsail/... -v -count 1 -parallel 20 -run=TestAccDisk_ -timeout 180m
=== RUN   TestAccDisk_basic
--- PASS: TestAccDisk_basic (49.63s)
=== RUN   TestAccDisk_Name
--- PASS: TestAccDisk_Name (94.55s)
=== RUN   TestAccDisk_Tags
--- PASS: TestAccDisk_Tags (107.61s)
=== RUN   TestAccDisk_disappears
--- PASS: TestAccDisk_disappears (48.14s)
PASS
ok      github.com/deyoungtech/terraform-provider-awslightsail/internal/lightsail       300.346s
...
```