### PR TITLE
Adding import for Static IP and IP attachment

### DIFF
--- a/docs/resources/static_ip.md
+++ b/docs/resources/static_ip.md
@@ -31,3 +31,11 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The ARN of the Lightsail static IP
 * `ip_address` - The allocated static IP address
 * `support_code` - The support code.
+
+## Import
+
+Lightsail Static IP addresses can be imported using their name, e.g.,
+
+``` shell
+terraform import awslightsail_static_ip.gitlab_test 'gitlab-ip'
+```

--- a/docs/resources/static_ip_attachment.md
+++ b/docs/resources/static_ip_attachment.md
@@ -43,3 +43,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `ip_address` - The allocated static IP address
+
+## Import
+
+Lightsail Static IP address attachment can be imported using the name of the IP, e.g.,
+
+``` shell
+terraform import awslightsail_static_ip_attachment.gitlab_test 'gitlab-ip'
+```

--- a/internal/lightsail/static_ip.go
+++ b/internal/lightsail/static_ip.go
@@ -18,6 +18,9 @@ func ResourceStaticIP() *schema.Resource {
 		Create: resourceStaticIPCreate,
 		Read:   resourceStaticIPRead,
 		Delete: resourceStaticIPDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -72,10 +75,9 @@ func resourceStaticIPCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceStaticIPRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).LightsailConn
 
-	name := d.Get("name").(string)
-	log.Printf("[INFO] Reading Lightsail Static IP: %q", name)
+	log.Printf("[INFO] Reading Lightsail Static IP: %q", d.Id())
 	resp, err := conn.GetStaticIp(context.TODO(), &lightsail.GetStaticIpInput{
-		StaticIpName: aws.String(name),
+		StaticIpName: aws.String(d.Id()),
 	})
 
 	if err != nil {
@@ -90,6 +92,7 @@ func resourceStaticIPRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", resp.StaticIp.Arn)
 	d.Set("ip_address", resp.StaticIp.IpAddress)
 	d.Set("support_code", resp.StaticIp.SupportCode)
+    d.Set("name", resp.StaticIp.Name)
 
 	return nil
 }

--- a/internal/lightsail/static_ip.go
+++ b/internal/lightsail/static_ip.go
@@ -92,7 +92,7 @@ func resourceStaticIPRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", resp.StaticIp.Arn)
 	d.Set("ip_address", resp.StaticIp.IpAddress)
 	d.Set("support_code", resp.StaticIp.SupportCode)
-    d.Set("name", resp.StaticIp.Name)
+	d.Set("name", resp.StaticIp.Name)
 
 	return nil
 }

--- a/internal/lightsail/static_ip_attachment.go
+++ b/internal/lightsail/static_ip_attachment.go
@@ -18,9 +18,9 @@ func ResourceStaticIPAttachment() *schema.Resource {
 		Create: resourceStaticIPAttachmentCreate,
 		Read:   resourceStaticIPAttachmentRead,
 		Delete: resourceStaticIPAttachmentDelete,
-        Importer: &schema.ResourceImporter{
-                State: schema.ImportStatePassthrough,
-        },
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"static_ip_name": {

--- a/internal/lightsail/static_ip_attachment.go
+++ b/internal/lightsail/static_ip_attachment.go
@@ -18,6 +18,9 @@ func ResourceStaticIPAttachment() *schema.Resource {
 		Create: resourceStaticIPAttachmentCreate,
 		Read:   resourceStaticIPAttachmentRead,
 		Delete: resourceStaticIPAttachmentDelete,
+        Importer: &schema.ResourceImporter{
+                State: schema.ImportStatePassthrough,
+        },
 
 		Schema: map[string]*schema.Schema{
 			"static_ip_name": {
@@ -89,6 +92,7 @@ func resourceStaticIPAttachmentRead(d *schema.ResourceData, meta interface{}) er
 
 	d.Set("instance_name", resp.StaticIp.AttachedTo)
 	d.Set("ip_address", resp.StaticIp.IpAddress)
+	d.Set("static_ip_name", d.Id())
 
 	return nil
 }

--- a/internal/lightsail/static_ip_attachment_test.go
+++ b/internal/lightsail/static_ip_attachment_test.go
@@ -34,6 +34,11 @@ func TestAccStaticIPAttachment_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "ip_address"),
 				),
 			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/lightsail/static_ip_test.go
+++ b/internal/lightsail/static_ip_test.go
@@ -31,6 +31,11 @@ func TestAccStaticIP_basic(t *testing.T) {
 					testAccCheckStaticIPExists(rName),
 				),
 			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
Adding the importing of the static_ip and static_ip_attachment
resources.

Build has been tested and works with some simple resources.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDomain_' PKG_NAME='internal/lightsail'

...
```