### PR TITLE
Add Resource: Certificate

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,6 +5,7 @@ PKG_NAME=internal
 TEST_COUNT?=1
 ACCTEST_TIMEOUT?=180m
 ACCTEST_PARALLELISM?=20
+AWS_REGION=us-east-1
 
 default: build
 

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -1,0 +1,38 @@
+---
+page_title: "AWS Lightsail: awslightsail_certificate"
+description: |-
+  Provides a lightsail certificate
+---
+
+# Resource: awslightsail_certificate
+
+Provides a lightsail certificate.
+
+## Example Usage
+
+```terraform
+resource "awslightsail_certificate" "test" {
+  name                      = "test"
+  domain_name               = "testdomain.com"
+  subject_alternative_names = ["www.testdomain.com"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Lightsail load balancer.
+* `domain_name` - (Required) A domain name for which the certificate should be issued
+* `subject_alternative_names` - (Optional) Set of domains that should be SANs in the issued certificate. 
+* `tags` - (Optional) A map of tags to assign to the resource. To create a key-only tag, use an empty string as the value. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the lightsail certificate (matches `name`).
+* `arn` - The ARN of the lightsail certificate.
+* `created_at` - The timestamp when the instance was created.
+* `domain_validation_options` - Set of domain validation objects which can be used to complete certificate validation. Can have more than one element, e.g., if SANs are defined.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -23,8 +23,8 @@ resource "awslightsail_certificate" "test" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Lightsail load balancer.
-* `domain_name` - (Required) A domain name for which the certificate should be issued
-* `subject_alternative_names` - (Optional) Set of domains that should be SANs in the issued certificate. 
+* `domain_name` - (Required) A domain name for which the certificate should be issued.
+* `subject_alternative_names` - (Optional) Set of domains that should be SANs in the issued certificate.
 * `tags` - (Optional) A map of tags to assign to the resource. To create a key-only tag, use an empty string as the value. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference

--- a/internal/create/hashcode.go
+++ b/internal/create/hashcode.go
@@ -1,0 +1,22 @@
+package create
+
+import (
+	"hash/crc32"
+)
+
+// StringHashcode hashes a string to a unique hashcode.
+//
+// crc32 returns a uint32, but for our use we need
+// and non negative integer. Here we cast to an integer
+// and invert it if the result is negative.
+func StringHashcode(s string) int {
+	v := int(crc32.ChecksumIEEE([]byte(s)))
+	if v >= 0 {
+		return v
+	}
+	if -v >= 0 {
+		return -v
+	}
+	// v == MinInt
+	return 0
+}

--- a/internal/create/hashcode_test.go
+++ b/internal/create/hashcode_test.go
@@ -1,0 +1,26 @@
+package create
+
+import (
+	"testing"
+)
+
+func TestStringHashcode(t *testing.T) {
+	v := "hello, world"
+	expected := StringHashcode(v)
+	for i := 0; i < 100; i++ {
+		actual := StringHashcode(v)
+		if actual != expected {
+			t.Fatalf("bad: %#v\n\t%#v", actual, expected)
+		}
+	}
+}
+
+func TestStringHashcode_positiveIndex(t *testing.T) {
+	// "2338615298" hashes to uint32(2147483648) which is math.MinInt32
+	ips := []string{"192.168.1.3", "192.168.1.5", "2338615298"}
+	for _, ip := range ips {
+		if index := StringHashcode(ip); index < 0 {
+			t.Fatalf("Bad Index %#v for ip %s", index, ip)
+		}
+	}
+}

--- a/internal/lightsail/certificate.go
+++ b/internal/lightsail/certificate.go
@@ -1,0 +1,282 @@
+package lightsail
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lightsail"
+	"github.com/aws/aws-sdk-go-v2/service/lightsail/types"
+	"github.com/aws/smithy-go"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/conns"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/create"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/tftags"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/verify"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func ResourceCertificate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCertificateCreate,
+		Read:   resourceCertificateRead,
+		Update: resourceCertificateUpdate,
+		Delete: resourceCertificateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(2, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with an alphabetic character"),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+[^._\-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+				),
+			},
+			"domain_name": {
+				// AWS Provider 3.0.0 aws_route53_zone references no longer contain a
+				// trailing period, no longer requiring a custom StateFunc
+				// to prevent ACM API error
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringDoesNotMatch(regexp.MustCompile(`\.$`), "cannot end with a period"),
+			},
+			"subject_alternative_names": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 253),
+						validation.StringDoesNotMatch(regexp.MustCompile(`\.$`), "cannot end with a period"),
+					),
+				},
+				Set: schema.HashString,
+			},
+			"tags":     TagsSchema(),
+			"tags_all": TagsSchemaComputed(),
+			// additional info returned from the API
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_validation_options": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"domain_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_record_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_record_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_record_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Set: domainValidationOptionsHash,
+			},
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceCertificateCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LightsailConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	req := lightsail.CreateCertificateInput{
+		CertificateName: aws.String(d.Get("name").(string)),
+		DomainName:      aws.String(d.Get("domain_name").(string)),
+	}
+
+	if v, ok := d.GetOk("subject_alternative_names"); ok {
+		req.SubjectAlternativeNames = expandSubjectAlternativeNames(v)
+	}
+
+	if len(tags) > 0 {
+		req.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	resp, err := conn.CreateCertificate(context.TODO(), &req)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Operations) == 0 {
+		return fmt.Errorf("No operations found for CreateCertificate request")
+	}
+
+	op := resp.Operations[0]
+	d.SetId(d.Get("name").(string))
+
+	err = waitLightsailOperation(conn, op.Id)
+	if err != nil {
+		return fmt.Errorf("Error waiting for Certificate (%s) to become ready: %s", d.Id(), err)
+	}
+
+	return resourceCertificateRead(d, meta)
+}
+
+func resourceCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LightsailConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	resp, err := conn.GetCertificates(context.TODO(), &lightsail.GetCertificatesInput{
+		CertificateName: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		var oe *smithy.OperationError
+		if errors.As(err, &oe) {
+			log.Printf("failed to call service: %s, operation: %s, error: %v", oe.Service(), oe.Operation(), oe.Unwrap())
+		}
+		d.SetId("")
+		return nil
+	}
+
+	if len(resp.Certificates) == 0 {
+		log.Printf("[WARN] Lightsail Certificate (%s) not found removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	i := resp.Certificates[0]
+
+	d.Set("name", i.CertificateName)
+	d.Set("domain_name", i.DomainName)
+	d.Set("subject_alternative_names", flattenSubjectAlternativeNames(i.CertificateDetail))
+
+	// additional attributes
+	d.Set("arn", i.CertificateArn)
+	d.Set("created_at", i.CertificateDetail.CreatedAt.Format(time.RFC3339))
+
+	d.Set("domain_validation_options", flattenDomainValidationRecords(i.CertificateDetail.DomainValidationRecords))
+
+	tags := KeyValueTags(i.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceCertificateDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	resp, err := conn.DeleteCertificate(context.TODO(), &lightsail.DeleteCertificateInput{
+		CertificateName: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	op := resp.Operations[0]
+
+	err = waitLightsailOperation(conn, op.Id)
+	if err != nil {
+		return fmt.Errorf("Error waiting for Certificate (%s) to become ready: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceCertificateUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating Lightsail Certificate (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceCertificateRead(d, meta)
+}
+
+func domainValidationOptionsHash(v interface{}) int {
+	m, ok := v.(map[string]interface{})
+
+	if !ok {
+		return 0
+	}
+
+	if v, ok := m["domain_name"].(string); ok {
+		return create.StringHashcode(v)
+	}
+
+	return 0
+}
+
+func flattenSubjectAlternativeNames(cert *types.Certificate) []string {
+	sans := cert.SubjectAlternativeNames
+	vs := make([]string, 0)
+	for _, v := range sans {
+		if v != aws.ToString(cert.DomainName) {
+			vs = append(vs, v)
+		}
+	}
+	return vs
+}
+
+func flattenDomainValidationRecords(domainValidationRecords []types.DomainValidationRecord) []map[string]interface{} {
+	var domainValidationResult []map[string]interface{}
+
+	for _, o := range domainValidationRecords {
+		if o.ResourceRecord != nil {
+			validationOption := map[string]interface{}{
+				"domain_name":           aws.ToString(o.DomainName),
+				"resource_record_name":  aws.ToString(o.ResourceRecord.Name),
+				"resource_record_type":  aws.ToString(o.ResourceRecord.Type),
+				"resource_record_value": aws.ToString(o.ResourceRecord.Value),
+			}
+			domainValidationResult = append(domainValidationResult, validationOption)
+		}
+	}
+
+	return domainValidationResult
+}
+
+func expandSubjectAlternativeNames(sans interface{}) []string {
+	subjectAlternativeNames := make([]string, len(sans.(*schema.Set).List()))
+	for i, sanRaw := range sans.(*schema.Set).List() {
+		subjectAlternativeNames[i] = sanRaw.(string)
+	}
+
+	return subjectAlternativeNames
+}

--- a/internal/lightsail/certificate_test.go
+++ b/internal/lightsail/certificate_test.go
@@ -1,0 +1,259 @@
+package lightsail_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lightsail"
+	"github.com/aws/smithy-go"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/conns"
+	"github.com/deyoungtech/terraform-provider-awslightsail/internal/testhelper"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccCertificate_basic(t *testing.T) {
+	rName := "awslightsail_certificate.test"
+	lName := fmt.Sprintf("tf-test-lightsail-%s.com", sdkacctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    testhelper.GetProviders(),
+		CheckDestroy: testAccCheckCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateConfig_basic(lName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCertificateExists(rName),
+					resource.TestCheckResourceAttr(rName, "name", lName),
+					resource.TestCheckResourceAttr(rName, "domain_name", lName),
+					resource.TestCheckResourceAttr(rName, "subject_alternative_names.#", "0"),
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "domain_validation_options.*", map[string]string{
+						"domain_name":          lName,
+						"resource_record_type": "CNAME",
+					}),
+					resource.TestCheckResourceAttrSet(rName, "arn"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttr(rName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCertificate_SubjectAlternativeNames(t *testing.T) {
+	rName := "awslightsail_certificate.test"
+	lName := fmt.Sprintf("tf-test-lightsail-%s.com", sdkacctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    testhelper.GetProviders(),
+		CheckDestroy: testAccCheckCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateConfig_SubjectAlternativeNames(lName, "www.test.com"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCertificateExists(rName),
+					resource.TestCheckResourceAttr(rName, "name", lName),
+					resource.TestCheckResourceAttr(rName, "domain_name", lName),
+					resource.TestCheckResourceAttr(rName, "subject_alternative_names.#", "1"),
+					resource.TestCheckTypeSetElemAttr(rName, "subject_alternative_names.*", "www.test.com"),
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "domain_validation_options.*", map[string]string{
+						"domain_name":          lName,
+						"resource_record_type": "CNAME",
+					}),
+					resource.TestCheckResourceAttrSet(rName, "arn"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttr(rName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCertificate_Tags(t *testing.T) {
+	rName := "awslightsail_certificate.test"
+	lName := fmt.Sprintf("tf-test-lightsail-%s.com", sdkacctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		Providers: testhelper.GetProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateConfigTags1(lName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCertificateExists(rName),
+					resource.TestCheckResourceAttr(rName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(rName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCertificateConfigTags2(lName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCertificateExists(rName),
+					resource.TestCheckResourceAttr(rName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(rName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(rName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccCertificateConfigTags1(lName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCertificateExists(rName),
+					resource.TestCheckResourceAttr(rName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(rName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCertificate_disappears(t *testing.T) {
+	rName := "awslightsail_certificate.test"
+	lName := fmt.Sprintf("tf-test-lightsail-%s.com", sdkacctest.RandString(5))
+
+	testDestroy := func(*terraform.State) error {
+		// reach out and DELETE the Certificate
+		conn := testhelper.GetProvider().Meta().(*conns.AWSClient).LightsailConn
+		_, err := conn.DeleteCertificate(context.TODO(), &lightsail.DeleteCertificateInput{
+			CertificateName: aws.String(lName),
+		})
+
+		if err != nil {
+			return fmt.Errorf("error deleting Lightsail Certificate in disappear test")
+		}
+
+		// sleep 7 seconds to give it time, so we don't have to poll
+		time.Sleep(7 * time.Second)
+
+		return nil
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    testhelper.GetProviders(),
+		CheckDestroy: testAccCheckCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateConfig_basic(lName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCertificateExists(rName),
+					testDestroy,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckCertificateDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "awslightsail_certificate" {
+			continue
+		}
+
+		conn := testhelper.GetProvider().Meta().(*conns.AWSClient).LightsailConn
+
+		respCertificate, err := conn.GetCertificates(context.TODO(), &lightsail.GetCertificatesInput{
+			CertificateName: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			if len(respCertificate.Certificates) > 0 {
+				return fmt.Errorf("Certificate %q still exists", rs.Primary.ID)
+			}
+		}
+
+		// Verify the error
+		if err != nil {
+			var oe *smithy.OperationError
+			if errors.As(err, &oe) {
+				log.Printf("failed to call service: %s, operation: %s, error: %v", oe.Service(), oe.Operation(), oe.Unwrap())
+			}
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckCertificateExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Certificate ID is set")
+		}
+
+		conn := testhelper.GetProvider().Meta().(*conns.AWSClient).LightsailConn
+
+		respCertificate, err := conn.GetCertificates(context.TODO(), &lightsail.GetCertificatesInput{
+			CertificateName: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if respCertificate == nil || respCertificate.Certificates == nil {
+			return fmt.Errorf("Certificate (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCertificateConfig_basic(lName string) string {
+	return fmt.Sprintf(`
+resource "awslightsail_certificate" "test" {
+  name        = %[1]q
+  domain_name = %[1]q
+}
+`, lName)
+}
+
+func testAccCertificateConfig_SubjectAlternativeNames(lName string, san string) string {
+	return fmt.Sprintf(`
+resource "awslightsail_certificate" "test" {
+  name                      = %[1]q
+  domain_name               = %[1]q
+  subject_alternative_names = [%[2]q]
+}
+`, lName, san)
+}
+
+func testAccCertificateConfigTags1(rName string, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "awslightsail_certificate" "test" {
+  name        = %[1]q
+  domain_name = %[1]q
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccCertificateConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "awslightsail_certificate" "test" {
+  name        = %[1]q
+  domain_name = %[1]q
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/internal/lightsail/provider.go
+++ b/internal/lightsail/provider.go
@@ -71,6 +71,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"awslightsail_bucket":               ResourceBucket(),
+			"awslightsail_certificate":          ResourceCertificate(),
 			"awslightsail_contact_method":       ResourceContactMethod(),
 			"awslightsail_container_deployment": ResourceContainerDeployment(),
 			"awslightsail_container_service":    ResourceContainerService(),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Add the ability to manage Lightsail Certificates using terraform. 
<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccCertificate_' PKG_NAME='internal/lightsail' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/lightsail/... -v -count 1 -parallel 20 -run=TestAccCertificate_ -timeout 180m
=== RUN   TestAccCertificate_basic
=== PAUSE TestAccCertificate_basic
=== RUN   TestAccCertificate_SubjectAlternativeNames
=== PAUSE TestAccCertificate_SubjectAlternativeNames
=== RUN   TestAccCertificate_Tags
--- PASS: TestAccCertificate_Tags (82.38s)
=== RUN   TestAccCertificate_disappears
=== PAUSE TestAccCertificate_disappears
=== CONT  TestAccCertificate_basic
=== CONT  TestAccCertificate_disappears
=== CONT  TestAccCertificate_SubjectAlternativeNames
--- PASS: TestAccCertificate_basic (38.53s)
--- PASS: TestAccCertificate_disappears (38.65s)
--- PASS: TestAccCertificate_SubjectAlternativeNames (40.56s)
PASS
ok      github.com/deyoungtech/terraform-provider-awslightsail/internal/lightsail       123.487s

...
```